### PR TITLE
require `Collection::Entity` to be `'static` to avoid breakage

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -93,7 +93,7 @@ pub trait FromDataFields: Sized {
 }
 
 pub trait Collection<'a>: IntoDataFields + FromDataFields {
-    type Entity: Entity;
+    type Entity: Entity + 'static;
     type IterRows: Iterator<Item = Self::Entity> + 'a;
     type IterColumns: Iterator<Item = FieldColumn<'static>> + 'a;
 


### PR DESCRIPTION
Your project will stop compiling starting in version 1.77. The core issue is `SearchCollection::iter` which returns `impl Iterator<Item = SearchEntry<<C as Collection<'a>>::Entity>> + '_`. `SearchEntry<E>` requires `E: 'static`. Currently `<C as Collection<'a>>::Entity` is not known to be `'static` and should error.

We previously did not error here, which was unsound and could result in use-after-free, e.g. https://rust.godbolt.org/z/oGzxjoYre. By adding the `'static` bound your crate will continue to compile